### PR TITLE
logging_level parameter as integer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-ssis-provider"
-version = "1.0.5"
+version = "1.0.6"
 authors = [
   { name="Glenn Schuurman", email="info@schuurman-it.com" },
 ]

--- a/src/SSIS_Operator/operators/ssis_package_operator.py
+++ b/src/SSIS_Operator/operators/ssis_package_operator.py
@@ -20,7 +20,7 @@ class SsisPackageOperator(BaseOperator):
     
     {sql_parameters}
     
-    DECLARE @LoggingLevel sql_variant = N'{logging_level}'  
+    DECLARE @LoggingLevel sql_variant = {logging_level}  
     EXEC [SSISDB].[catalog].[set_execution_parameter_value] @execution_id, @object_type=50, @parameter_name=N'LOGGING_LEVEL', @parameter_value=@LoggingLevel;
        
     EXEC [SSISDB].[catalog].[start_execution] @execution_id;


### PR DESCRIPTION
logging_level parameter in sql script changed to int datatype in query by removing quotes